### PR TITLE
Fix textarea name in Chapter 10

### DIFF
--- a/code/ch10/protcharge.py
+++ b/code/ch10/protcharge.py
@@ -17,7 +17,7 @@ def chargeandprop(aa_seq):
 cgitb.enable()
 print('Content-Type: text/html\n')
 form = cgi.FieldStorage()
-seq = form.getvalue('seq', 'QWERTYYTREWQRTYEYTRQWE')
+seq = form.getvalue('aaseq', 'QWERTYYTREWQRTYEYTRQWE')
 prop = form.getvalue('prop', 'n')
 jobtitle = form.getvalue('title','No title')
 charge, propvalue = chargeandprop(seq)


### PR DESCRIPTION
protchage.html has textarea whose name is 'aaseq' .

- Before (name is  seq)
    - seq = form.getvalue('seq', 'QWERTYYTREWQRTYEYTRQWE')
- After
    - seq = form.getvalue('aaseq', 'QWERTYYTREWQRTYEYTRQWE')